### PR TITLE
Node.jsのHTMLサーバーを使ってHTMLを返す処理の実装

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,10 @@
 const http = require('http');
 const server = http.createServer((req, res) => {
   res.writeHead(200, {
-    'Content-Type': 'text/plain; charset=utf-8'
+    'Content-Type': 'text/html; charset=utf-8'
   });
-  res.write(req.headers['user-agent']);
+  //res.write(req.headers['user-agent']);
+  res.write('<!DOCTYPE html><html lang="ja"><body><h1>HTMLの一番大きい見出しを表示します</h1></body></html>');
   res.end();
 });
 const port = 8000;


### PR DESCRIPTION
#### 失敗１
res.write()に渡すHTMLの文字列内で、""ダブルコーテーションとダブルクォーテーションがかぶっていたためエラーが表示された。

↑
外のコーテーションマークをシングルコートマークに変更。→解決

#### 失敗２
git cloneし、再度実施
Content-Typeがtext/plainだったためHTMLがそのまま表示された
↓
text/htmlに変更→解決
