### PR TITLE
HTTPサーバーの表示変更

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,9 @@
 const http = require('http');
 const server = http.createServer((req, res) => {
   res.writeHead(200, {
-    'Content-Type': 'text/plain; charset=utf-8'
+    'Content-Type': 'text/html; charset=utf-8'
   });
-  res.write(req.headers['user-agent']);
+  res.write('<!DOCTYPE html><html lang="ja"><body><h1>HTMLの一番大きい見出しを表示します</h1></body></html>');
   res.end();
 });
 const port = 8000;


### PR DESCRIPTION
Chromebook + Cloud9という環境のため、8000番ポートが使えずサーバーを建てるのに苦労した。
結果的にポートを8080, 8081 or 8082、IPを127.0.0.1 or localhostにすることで解決。